### PR TITLE
[buxfix / COL-28] Show JumboImage instead of JumboGallery when gallery is empty | fix m…

### DIFF
--- a/src/components/GalleryBlur/GalleryBlur.js
+++ b/src/components/GalleryBlur/GalleryBlur.js
@@ -15,7 +15,7 @@ const GalleryBlur = ({ galleryDesktop = [], galleryMobile = [], onSwiper }) => {
         effect="fade"
         loop={true}
         loopAdditionalSlides={1}
-        lazy={true}
+        lazy={{ loadPrevNext: true }}
         allowTouchMove={false}
         className="h-[472px] md:h-[578px]"
       >
@@ -23,10 +23,10 @@ const GalleryBlur = ({ galleryDesktop = [], galleryMobile = [], onSwiper }) => {
           <SwiperSlide key={item.id} className="overflow-hidden">
             <picture>
               {galleryDesktop[index]?.srcSet && (
-                <source data-srcset={galleryDesktop[index]?.srcSet} sizes={galleryDesktop[index]?.sizes} media={md} />
+                <source data-srcset={galleryDesktop[index]?.srcSet} sizes="(min-width: 768px) 950px, 90vw" media={md} />
               )}
               {galleryMobile && galleryMobile[index]?.srcSet && (
-                <source data-srcset={galleryMobile[index].srcSet} sizes={galleryMobile[index].sizes} />
+                <source data-srcset={galleryMobile[index].srcSet} sizes="(min-width: 768px) 950px, 90vw" />
               )}
               <img
                 data-src={galleryDesktop[index].sourceUrl}

--- a/src/components/JumboGallery/JumboGallery.js
+++ b/src/components/JumboGallery/JumboGallery.js
@@ -1,16 +1,17 @@
 // core version + navigation, pagination modules:
-import { useLayoutEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import GalleryBlur from 'components/GalleryBlur';
 import Gallery from 'components/Gallery';
 import GalleryInfoCard from 'components/GalleryInfoCard';
 import GalleryInfo from 'components/GalleryInfo';
+import JumboImage from 'components/JumboImage';
 
 const JumboGallery = ({ galleryDesktop = [], galleryMobile, featuredImage, square = false, info = false }) => {
   const swiperGallery = useRef(null);
   const swiperInfo = useRef(null);
   const swiperBlur = useRef(null);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (swiperGallery.current) {
       swiperGallery.current.controller.control = swiperBlur.current;
       swiperBlur.current.controller.control = swiperInfo.current;
@@ -56,15 +57,14 @@ const JumboGallery = ({ galleryDesktop = [], galleryMobile, featuredImage, squar
           )}
         </>
       ) : (
-        <div className="md:h=[578px] h-[472px] w-full overflow-hidden">
-          <img
-            src={featuredImage.sourceUrl}
-            alt={featuredImage.altText}
-            srcSet={featuredImage.srcSet}
-            sizes="100vw"
-            className="h-full w-full object-cover object-center"
-          />
-        </div>
+        <>
+          {featuredImage && <JumboImage imageDesktop={featuredImage} />}
+          {info && square && (
+            <div className="absolute -bottom-5 left-[35%] z-20 -translate-x-1/2 md:left-[35%]">
+              <GalleryInfoCard title={info.title} subtitle={info.subtitle} button={info.button} />
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -11,26 +11,29 @@ const Nav = () => {
   const { title } = metadata;
 
   return (
-    <nav>
-      <div className="navbar | container mx-auto flex items-center justify-between p-2 md:space-x-8">
-        <div className="nav-left | shrink-0">
-          <Link href="/">
-            <a>
-              <img
-                src="https://admin.colourfulbirding.com/wp-content/uploads/images/colourful-nav-logo.png"
-                alt={title}
-                width={167}
-                height={50}
-                loading="lazy"
-              />
-            </a>
-          </Link>
+    <div className="">
+      {isOpen && <div className="relative -z-20 h-[70.15px] w-full" />}
+      <nav className={`navbar ${isOpen && 'fixed top-0 z-50 w-full bg-white'}`}>
+        <div className={`container mx-auto flex items-center justify-between p-2 md:space-x-8`}>
+          <div className="nav-left | shrink-0">
+            <Link href="/">
+              <a>
+                <img
+                  src="https://admin.colourfulbirding.com/wp-content/uploads/images/colourful-nav-logo.png"
+                  alt={title}
+                  width={167}
+                  height={50}
+                  loading="lazy"
+                />
+              </a>
+            </Link>
+          </div>
+          <NavMenu isOpen={isOpen} />
+          <BurgerButton isOpen={isOpen} onClick={() => setIsOpen(!isOpen)} className="mobileMenuBtn | md:hidden" />
         </div>
-        <NavMenu isOpen={isOpen} />
-        <BurgerButton isOpen={isOpen} onClick={() => setIsOpen(!isOpen)} className="mobileMenuBtn | md:hidden" />
-      </div>
-      <DividerH />
-    </nav>
+        <DividerH />
+      </nav>
+    </div>
   );
 };
 

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -50,7 +50,9 @@ export function sortObjectsRamdomly(arr) {
 
 export function getFirstPathname(url) {
   if (typeof url !== 'string') return;
-  return url.split('/')[1];
+  const pathArray = [...url.split('/')];
+  const filteredPathArray = pathArray.filter((el) => el !== '');
+  return filteredPathArray[filteredPathArray.length - 1];
 }
 
 /**


### PR DESCRIPTION
## Jira ticket
COL-28

## Description
Show JumboImage instead of JumboGallery when gallery is empty | fix mobile menu nav | paint nav link when page is active

## Tasks
- [x] Show JumboImage instead of JumboGallery when gallery is empty
- [x] fix mobile menu nav 
- [x] paint nav link when page is active

## Version Control
- [x] This is a patch
- [ ] This is a minor change (non breaking, backwards compatible, enhancement) 
- [ ] This is a major change (breaking changes) 

## Testing
- [ ] Add unit tests
- [ ] Ran unit tests successfully

## Documentation
- [ ] Documentation changes applied for public APIs
- [ ] Update README / Wiki